### PR TITLE
Upgrade GitHub Action Workflow Versions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
 
       - name: changelog-ci
-        uses: saadmk11/changelog-ci@test-yaml-config
+        uses: saadmk11/changelog-ci@v0.7.5
         with:
           changelog_filename: MY_CHANGELOG.md
           config_file: changelog-ci-config.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 


### PR DESCRIPTION
#### GitHub Actions Version Upgrades
* **actions/checkout** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
* **saadmk11/changelog-ci** published a new release [v0.7.5](https://github.com/saadmk11/changelog-ci/releases/tag/v0.7.5) on 2021-04-06T06:32:41Z
* **actions/checkout** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
