### PR TITLE
Upgrade GitHub Action Versions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: changelog-ci
-        uses: saadmk11/changelog-ci@test-yaml-config
+        uses: saadmk11/changelog-ci@v0.7.5
         with:
           changelog_filename: MY_CHANGELOG.md
           config_file: changelog-ci-config.yaml

--- a/.github/workflows/new.yaml
+++ b/.github/workflows/new.yaml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.9
       - run: python -m pip install flake8
       - name: flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: flake8
           run: flake8
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.9
       - run: python -m pip install isort
       - name: isort
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: isort
           run: isort --check --diff django tests scripts

--- a/.github/workflows/new4.yaml
+++ b/.github/workflows/new4.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         coverage run --parallel -m pytest -x
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.3.2
       with:
         fail_ci_if_error: true
   lint_python:
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
     - name: Install dependencies
       run: |
         npm ci


### PR DESCRIPTION
### GitHub Actions Version Upgrades
* **[saadmk11/changelog-ci](https://github.com/saadmk11/changelog-ci)** published a new release [v0.7.5](https://github.com/saadmk11/changelog-ci/releases/tag/v0.7.5) on 2021-04-06T06:32:41Z
* **[liskin/gh-problem-matcher-wrap](https://github.com/liskin/gh-problem-matcher-wrap)** published a new release [v1.0.1](https://github.com/liskin/gh-problem-matcher-wrap/releases/tag/v1.0.1) on 2021-03-27T21:36:33Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v2.1.5](https://github.com/actions/setup-node/releases/tag/v2.1.5) on 2021-02-22T15:13:04Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v1.3.2](https://github.com/codecov/codecov-action/releases/tag/v1.3.2) on 2021-04-05T14:53:18Z
