### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
 
       - name: changelog-ci
-        uses: saadmk11/changelog-ci@test-yaml-config
+        uses: saadmk11/changelog-ci@v0.7.5
         with:
           changelog_filename: MY_CHANGELOG.md
           config_file: changelog-ci-config.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-action-upgrade@remove-duplicate-comment-line
+        uses: saadmk11/github-action-upgrade@v0.5.5
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/new.yaml
+++ b/.github/workflows/new.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - run: python -m pip install flake8
       - name: flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: flake8
           run: flake8
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - run: python -m pip install isort
       - name: isort
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: isort
           run: isort --check --diff django tests scripts

--- a/.github/workflows/new2.yaml
+++ b/.github/workflows/new2.yaml
@@ -17,13 +17,13 @@ jobs:
         - '3.9'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v2.1.4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}

--- a/.github/workflows/new4.yaml
+++ b/.github/workflows/new4.yaml
@@ -23,7 +23,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -44,13 +44,13 @@ jobs:
       run: |
         coverage run --parallel -m pytest -x
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.3.2
       with:
         fail_ci_if_error: true
   lint_python:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -66,9 +66,9 @@ jobs:
   lint_js:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Set up NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
     - name: Install dependencies
       run: |
         npm ci
@@ -78,7 +78,7 @@ jobs:
   sandbox:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -90,7 +90,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/new5.yaml
+++ b/.github/workflows/new5.yaml
@@ -14,7 +14,7 @@ jobs:
           - black-template
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -41,7 +41,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -75,7 +75,7 @@ jobs:
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/postgres"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/new6.yaml
+++ b/.github/workflows/new6.yaml
@@ -24,7 +24,7 @@ jobs:
           # - "master"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -59,7 +59,7 @@ jobs:
           - "31"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[liskin/gh-problem-matcher-wrap](https://github.com/liskin/gh-problem-matcher-wrap)** published a new release [v1.0.1](https://github.com/liskin/gh-problem-matcher-wrap/releases/tag/v1.0.1) on 2021-03-27T21:36:33Z
* **[saadmk11/github-action-upgrade](https://github.com/saadmk11/github-action-upgrade)** published a new release [v0.5.5](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.5.5) on 2021-04-08T15:44:25Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v2.1.5](https://github.com/actions/setup-node/releases/tag/v2.1.5) on 2021-02-22T15:13:04Z
* **[saadmk11/changelog-ci](https://github.com/saadmk11/changelog-ci)** published a new release [v0.7.5](https://github.com/saadmk11/changelog-ci/releases/tag/v0.7.5) on 2021-04-06T06:32:41Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v2.1.4](https://github.com/actions/cache/releases/tag/v2.1.4) on 2021-02-04T19:16:35Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v1.3.2](https://github.com/codecov/codecov-action/releases/tag/v1.3.2) on 2021-04-05T14:53:18Z
